### PR TITLE
src: sqlite: match previous postings on url rather than title

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -42,8 +42,8 @@ pub fn check_prepost(db: &Connection, e: &LogEntry) -> Option<PrevPost>
 {
     let query = format!("SELECT user, time_created, channel
                          FROM posts
-                         WHERE title LIKE \"{}\"",
-            e.title.clone()
+                         WHERE url LIKE \"{}\"",
+            e.url.clone()
             .replace("\"", "\"\""));
 
     let mut st = db.prepare(&query).unwrap();


### PR DESCRIPTION
Rather than match titles, which previously seemed to be a good way to match
urls from redirects (may not actually be an issue if the redirected url is
the url actually stored), match on urls instead.

This should also be resilient to titles such as:

     <danny> wall-e: http://imgur.com/a/5XyPSuv
    <wall-e> ⤷ Imgur: The magic of the Internet