### PR TITLE
Implement various limits

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -3,6 +3,7 @@ extern crate htmlescape;
 
 use self::curl::easy::{Easy2, Handler, WriteError, List};
 use self::htmlescape::decode_html;
+use std::time::Duration;
 
 #[derive(Debug)]
 struct Collector(Vec<u8>);
@@ -24,6 +25,7 @@ pub fn resolve_url(url: &str, lang: &str) -> Option<String> {
     easy.url(url).unwrap();
     easy.follow_location(true).unwrap();
     easy.max_redirections(10).unwrap();
+    easy.timeout(Duration::from_secs(5)).unwrap();
     easy.useragent("url-bot-rs/0.1").unwrap();
 
     let mut headers = List::new();

--- a/src/http.rs
+++ b/src/http.rs
@@ -23,6 +23,7 @@ pub fn resolve_url(url: &str, lang: &str) -> Option<String> {
     easy.get(true).unwrap();
     easy.url(url).unwrap();
     easy.follow_location(true).unwrap();
+    easy.max_redirections(10).unwrap();
     easy.useragent("url-bot-rs/0.1").unwrap();
 
     let mut headers = List::new();

--- a/src/http.rs
+++ b/src/http.rs
@@ -26,6 +26,7 @@ pub fn resolve_url(url: &str, lang: &str) -> Option<String> {
     easy.follow_location(true).unwrap();
     easy.max_redirections(10).unwrap();
     easy.timeout(Duration::from_secs(5)).unwrap();
+    easy.max_recv_speed(10 * 1024 * 1024).unwrap();
     easy.useragent("url-bot-rs/0.1").unwrap();
 
     let mut headers = List::new();


### PR DESCRIPTION
- Limit number of redirects to 10 (Fixes #23)
- Timeout requests after 5 seconds (Fixes #24)
- Limit download speed to 10MB/s (Fixes #24)

Note that there is a [method to limit the filesize](https://docs.rs/curl/0.4.18/curl/easy/struct.Easy2.html#method.max_filesize),
but it [isn't a safe way to ensure a hard limit](https://curl.haxx.se/libcurl/c/CURLOPT_MAXFILESIZE.html):

> The file size is not always known prior to download, and for such files this option has no effect even if the file transfer ends up being larger than this given limit.

To solve this I limit both the download speed and the maximum request time,
so that the resulting data can only be about 50MB at most.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nuxeh/url-bot-rs/25)
<!-- Reviewable:end -->
