### PR TITLE
Fix issue with directory creation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -225,7 +225,7 @@ impl_display!(Features, Parameters, Database);
 
 fn create_dir_if_missing(dir: &Path) -> Result<bool, Error> {
     let pdir = dir.to_str().unwrap();
-    let exists = dir.exists();
+    let exists = pdir.is_empty() || dir.exists();
     if !exists {
         eprintln!("Directory `{}` doesn't exist, creating it", pdir);
         fs::create_dir_all(dir)?;


### PR DESCRIPTION
url-bot now checks to see if the parent directory of the configuration and
database exists before looking for the file, so that if they're missing, they
can be created. However, if the specified paths are relative paths in the CWD,
this results in an empty parent path, leading to the following:
```
$ target/debug/url-bot-rs --db=tmpdb --conf=tmpconf
Directory `` doesn't exist, creating it
Directory `` doesn't exist, creating it
Using configuration: tmpconf
Using database: tmpdb
```

After this patch, we have:
```
$ target/debug/url-bot-rs --db=tmpdb --conf=tmpconf`
Using configuration: tmpconf
Using database: tmpdb
```