### PR TITLE
Updates to queries

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -19,6 +19,7 @@ pub fn handle_message(
         _ => return,
     };
 
+    let is_chanmsg = target.starts_with('#');
     let user = message.source_nickname().unwrap();
     let mut num_processed = 0;
 
@@ -85,7 +86,7 @@ pub fn handle_message(
             },
             Ok(None) => {
                 // add new log entry to database
-                if rtd.history {
+                if rtd.history && is_chanmsg {
                     if let Err(err) = db.add_log(&entry) {
                         error!("SQL error: {}", err);
                     }
@@ -105,7 +106,7 @@ pub fn handle_message(
 
         // send the IRC response
         let target = message.response_target().unwrap_or(target);
-        if rtd.conf.features.send_notice {
+        if rtd.conf.features.send_notice && is_chanmsg {
             client.send_notice(target, &msg).unwrap()
         } else {
             client.send_privmsg(target, &msg).unwrap()


### PR DESCRIPTION
Include a couple of changes of behaviour in handling queries. Since
noone else sees queries, these should be a private thing between
url-bot-rs and the user, so it isn't important that links have been
posted in queries, and when a link is posted in a channel, this should
not register as a pre-post. It is a feasible use case to use a query
with url-bot-rs to test links before posting in a channel, for example.
Furthermore, don't send notices in queries, since this isn't
particularly relevant or desirable.

- Respond with private message rather than notices in queries, even if
  set to reply with notice in channels.
- Query the database (if enabled) for previous postings, report as
  normal, but don't add posted links to the database.

Closes #105
Closes #93