### PR TITLE
Do not recompile if no source has changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 use man::prelude::*;
 
 fn main() {
+    println!("cargo:rerun-if-changed=src");
     built::write_built_file().expect("Failed to store build-time information");
     generate_manpage();
 }


### PR DESCRIPTION
Printing "cargo:rerun-if-changed=src" in `build.rs` stops it from running and
recompiling the package if nothing in src has been changed.

Not sure if additional paths should be added to this.

Some more detail on this option [here](https://doc.rust-lang.org/cargo/reference/build-scripts.html)