### PR TITLE
Nickname call response

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ operation, specified in the `[features]` section:
   out the active configuration with an updated list of channels.
 - `send_errors_to_poster` (bool) if enabled, sends any errors occurring when
   trying to resolve a link to the user posting the link, in a private message.
+- `nick_response` (bool) if enabled, the bot will respond to pings with
+  `nick_response` set in parameters.
 
 The `[parameters]` section includes a number of tunable parameters:
 
 - `url_limit` (u8) max number of URLs to process for each message (default: 10)
 - `accept_lang` (String) language requested in http content requests
   (default: "en")
+- `nick_response` (String) the response to pings the bot will send when
+  `nick_response` in features is set to true. (default: "beep boop")
 
 The `[database]` section contains options for the database, as follows:
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -7,11 +7,13 @@ history = false
 invite = false
 autosave = false
 send_errors_to_poster = false
+nick_response = false
 
 [parameters]
 url_limit = 10
 accept_lang = "en"
 status_channels = []
+nick_response = "beep boop"
 
 [database]
 path = ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Features {
     pub invite: bool,
     pub autosave: bool,
     pub send_errors_to_poster: bool,
+    pub nick_response: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -50,6 +51,7 @@ pub struct Parameters {
     pub url_limit: u8,
     pub accept_lang: String,
     pub status_channels: Vec<String>,
+    pub nick_response: String,
 }
 
 impl Default for Parameters {
@@ -58,6 +60,7 @@ impl Default for Parameters {
             url_limit: 10,
             accept_lang: "en".to_string(),
             status_channels: vec![],
+            nick_response: "beep boop".to_string()
         }
     }
 }


### PR DESCRIPTION
Adds an option to set a response in features, which will be sent whenever a user says url-bot-rs's nick.

Based on #158.

Closes issue #123