### PR TITLE
Error reporting over IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ operation, specified in the `[features]` section:
 - `invite` (bool) if enabled, `/invite` will cause the bot to join a channel.
 - `autosave` (bool) if enabled, `/invite` and `/kick` will automatically write
   out the active configuration with an updated list of channels.
+- `send_errors_to_poster` (bool) if enabled, sends any errors occurring when
+  trying to resolve a link to the user posting the link, in a private message.
 
 The `[parameters]` section includes a number of tunable parameters:
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -11,6 +11,7 @@ send_errors_to_poster = false
 [parameters]
 url_limit = 10
 accept_lang = "en"
+status_channels = []
 
 [database]
 path = ""

--- a/example.config.toml
+++ b/example.config.toml
@@ -6,6 +6,7 @@ send_notice = false
 history = false
 invite = false
 autosave = false
+send_errors_to_poster = false
 
 [parameters]
 url_limit = 10

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Features {
     pub history: bool,
     pub invite: bool,
     pub autosave: bool,
+    pub send_errors_to_poster: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,13 +49,15 @@ impl Default for Database {
 pub struct Parameters {
     pub url_limit: u8,
     pub accept_lang: String,
+    pub status_channels: Vec<String>,
 }
 
 impl Default for Parameters {
     fn default() -> Self {
         Self {
             url_limit: 10,
-            accept_lang: "en".to_string()
+            accept_lang: "en".to_string(),
+            status_channels: vec![],
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -251,7 +251,7 @@ pub fn get_title(resp: &mut Response, rtd: &Rtd, dump: bool) -> Result<String, E
         }
     }
 
-    bail!("failed to parse title");
+    bail!(format!("{}: failed to parse title", resp.url()));
 }
 
 #[cfg(test)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -114,6 +114,9 @@ fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, targ
             Ok(title) => title,
             Err(err) => {
                 error!("{:?}", err);
+                if rtd.conf.features.send_errors_to_poster {
+                    client.send_privmsg(user, err).unwrap()
+                }
                 continue
             },
         };

--- a/src/message.rs
+++ b/src/message.rs
@@ -114,8 +114,9 @@ fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, targ
             Ok(title) => title,
             Err(err) => {
                 error!("{:?}", err);
+                msg_status_chans(client, rtd, &err);
                 if rtd.conf.features.send_errors_to_poster {
-                    client.send_privmsg(user, err).unwrap()
+                    client.send_privmsg(user, &err).unwrap()
                 }
                 continue
             },
@@ -247,6 +248,32 @@ pub fn add_scheme_for_tld(token: &str) -> Option<String> {
     }
 
     None
+}
+
+/// join any status channels not already joined and send a message to them
+pub fn msg_status_chans<S>(client: &IrcClient, rtd: &Rtd, msg: S)
+where
+    S: ToString,
+    S: std::fmt::Display,
+{
+    if rtd.conf.params.status_channels.is_empty() {
+        return;
+    };
+
+    let joined_channels = client.list_channels().unwrap_or_else(|| vec![]);
+
+    rtd.conf.params.status_channels
+        .iter()
+        .filter(|c| !joined_channels.contains(c))
+        .for_each(|c| client.send_join(c).unwrap_or_else(|err| {
+            error!("Error joining status channel {}: {}", c, err)
+        }));
+
+    rtd.conf.params.status_channels
+        .iter()
+        .for_each(|c| client.send_privmsg(c, &msg).unwrap_or_else(|err| {
+            error!("Error messaging status channel {}: {}", c, err)
+        }));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add features to:
- Send private messages to posters of links containing error information
- Specify channels to send error information to

if any errors occur during URL resolution.