### PR TITLE
Send error messages as notices, add feature to reply with errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ operation, specified in the `[features]` section:
   out the active configuration with an updated list of channels.
 - `send_errors_to_poster` (bool) if enabled, sends any errors occurring when
   trying to resolve a link to the user posting the link, in a private message.
+- `reply_with_errors` (bool) if enabled, always reply with error messages.
 
 The `[parameters]` section includes a number of tunable parameters:
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -7,6 +7,7 @@ history = false
 invite = false
 autosave = false
 send_errors_to_poster = false
+reply_with_errors = false
 
 [parameters]
 url_limit = 10

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Features {
     pub invite: bool,
     pub autosave: bool,
     pub send_errors_to_poster: bool,
+    pub reply_with_errors: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -290,7 +290,6 @@ where
             error!("Error joining status channel {}: {}", c, err)
         }));
 
-
     rtd.conf.params.status_channels
         .iter()
         .for_each(|c| respond(client, rtd, c, &msg));

--- a/src/message.rs
+++ b/src/message.rs
@@ -73,6 +73,7 @@ fn invite(client: &IrcClient, rtd: &mut Rtd, nick: &str, chan: &str) {
 }
 
 fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, target: &str, msg: &str) {
+    let target = message.response_target().unwrap_or(target);
     let is_chanmsg = target.starts_with('#');
     let user = message.source_nickname().unwrap();
     let mut num_processed = 0;
@@ -116,9 +117,12 @@ fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, targ
                 error!("{:?}", err);
                 msg_status_chans(client, rtd, &err);
                 if rtd.conf.features.send_errors_to_poster {
-                    client.send_privmsg(user, &err).unwrap()
-                }
-                continue
+                    respond(client, rtd, user, &err);
+                };
+                if rtd.conf.features.reply_with_errors {
+                    respond(client, rtd, target, &err);
+                };
+                continue;
             },
         };
 
@@ -153,7 +157,7 @@ fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, targ
                 )
             },
             Ok(None) => {
-                // add new log entry to database
+                // add new log entry to database, if posted in a channel
                 if rtd.history && is_chanmsg {
                     if let Err(err) = db.add_log(&entry) {
                         error!("SQL error: {}", err);
@@ -173,13 +177,7 @@ fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, targ
         // log
         info!("{}", msg);
 
-        // send the IRC response
-        let target = message.response_target().unwrap_or(target);
-        if rtd.conf.features.send_notice && is_chanmsg {
-            client.send_notice(target, &msg).unwrap()
-        } else {
-            client.send_privmsg(target, &msg).unwrap()
-        }
+        respond(client, rtd, target, msg);
 
         dedup_urls.insert(url);
 
@@ -189,6 +187,25 @@ fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, targ
             break;
         }
     };
+}
+
+/// send IRC response
+fn respond<S>(client: &IrcClient, rtd: &Rtd, target: &str, msg: S)
+where
+    S: ToString,
+    S: std::fmt::Display,
+{
+    let is_chanmsg = target.starts_with('#');
+
+    let result = if rtd.conf.features.send_notice && is_chanmsg {
+        client.send_notice(target, &msg)
+    } else {
+        client.send_privmsg(target, &msg)
+    };
+
+    result.unwrap_or_else(|err| {
+        error!("Error sending response {}: {}", target, err);
+    });
 }
 
 // regex for unsafe characters, as defined in RFC 1738
@@ -273,11 +290,10 @@ where
             error!("Error joining status channel {}: {}", c, err)
         }));
 
+
     rtd.conf.params.status_channels
         .iter()
-        .for_each(|c| client.send_privmsg(c, &msg).unwrap_or_else(|err| {
-            error!("Error messaging status channel {}: {}", c, err)
-        }));
+        .for_each(|c| respond(client, rtd, c, &msg));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Break out the response code into a function, and add a feature to always reply with errors to the channel where links are posted.

Respond to status channels appropriately with notices if configured to do so.