### PR TITLE
Make partial (no scheme) URL matching optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ operation, specified in the `[features]` section:
 - `send_errors_to_poster` (bool) if enabled, sends any errors occurring when
   trying to resolve a link to the user posting the link, in a private message.
 - `reply_with_errors` (bool) if enabled, always reply with error messages.
+- `partial_urls` (bool) attempt to resolve titles for URLs without scheme, e.g.
+  "docs.rs".
 
 The `[parameters]` section includes a number of tunable parameters:
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -8,6 +8,7 @@ invite = false
 autosave = false
 send_errors_to_poster = false
 reply_with_errors = false
+partial_urls = false
 
 [parameters]
 url_limit = 10

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub struct Features {
     pub autosave: bool,
     pub send_errors_to_poster: bool,
     pub reply_with_errors: bool,
+    pub partial_urls: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -80,7 +80,12 @@ fn privmsg(client: &IrcClient, message: &Message, rtd: &Rtd, db: &Database, targ
         }
 
         // get a full URL for tokens without a scheme
-        let maybe_token = add_scheme_for_tld(token);
+        let maybe_token = if rtd.conf.features.partial_urls {
+            add_scheme_for_tld(token)
+        } else {
+            None
+        };
+
         let token = maybe_token
             .as_ref()
             .map_or(token, String::as_str);


### PR DESCRIPTION
Now partial URL matching is done optionally, based on configuration.

Fixes #216