### PR TITLE
Multiple instances/config overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
-# v0.2.2
+# v0.2.3
 
-# v0.2.1
+- Add capability of running multiple instances, to connect to multiple IRC
+  networks
+- Remove `--db` command line parameter
+- Add `--conf-dir` command line parameter, allowing configurations to be
+  searched for and loaded from a directory
+- Add a configuration file section, `network`, which may be used to specify a
+  network name, and to enable or disable it
+- Use network name to create a default sqlite db path
+- Allow multiple `--conf` command line parameters
+- Fix a bug whereby the bot would load any valid TOML as a configuration, using
+  default values
+- Use an enum underneath for database type in configuration, refactor sqlite
+  database path handling
+- Add IRC server reconnection
+- Improve test coverage
+
+# v0.2.2
 
 - Nick response
 - Refactor IRC error reporting
+- Improve test coverage
 
-# v0.2.0
+# v0.2.1
 
 - URL de-duplication
 - Addition of preliminary Nix files
@@ -30,6 +47,6 @@
 - Unified configuration and XDG paths
 - Ignore tokens containing invalid characters in URLs
 
-# v0.1.0
+# v0.2.0
 
 Initial development

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "c2-chacha"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,7 +981,7 @@ dependencies = [
  "schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1155,6 +1163,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,12 +1228,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1237,11 +1271,27 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1671,12 +1721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tempfile"
-version = "3.0.7"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2065,6 +2115,7 @@ dependencies = [
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2174,6 +2225,7 @@ dependencies = [
 "checksum built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2315cfb416f86e05360edc950b1d7d25ecfb00f7f8eba60dbd7882a0f2e944"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
+"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
@@ -2290,6 +2342,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum png 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f54b9600d584d3b8a739e1662a595fab051329eff43f20e7d8cc22872962145b"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afdc77cc74ec70ed262262942ebb7dac3d479e9e5cfa2da1841c0806f6cdabcc"
@@ -2297,10 +2350,14 @@ dependencies = [
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 "checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
 "checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
@@ -2350,7 +2407,7 @@ dependencies = [
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
+"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum tendril 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum thin-slice 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ name = "built"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -155,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.6"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -716,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1636,7 +1636,7 @@ name = "stderrlog"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1779,7 +1779,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2093,6 +2093,7 @@ version = "0.2.2"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "built 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2228,7 +2229,7 @@ dependencies = [
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
-"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
 "checksum chunked_transfer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "498d20a7aaf62625b9bf26e637cf7736417cde1d0c99f1d04d1170229a85cf87"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ man = "0.3.0"
 [dev-dependencies]
 tiny_http = "0.6.2"
 diff = "0.1.11"
+tempfile = "3.1.0"
 
 [dependencies]
 irc = "0.13.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ stderrlog = "0.4.1"
 atty = "0.2.13"
 scraper = { version = "0.11.0", default-features = false, features = [] }
 phf = "0.7.24"
+chrono = "0.4.10"
 
 [package.metadata.deb]
 extended-description = """\

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ or, if `$XDG_CONFIG_PATH` is set:
 
     $XDG_CONFIG_HOME/url-bot-rs/config.toml
 
+The `--conf` parameter may be provided multiple times, in order to connect to
+multiple servers/networks.
+
 ### Configuration file options
 
 The configuration includes settings pertaining to the IRC server the bot will

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The `[parameters]` section includes a number of tunable parameters:
 - `status_channels` (list) channel(s) to create, join and message with any
   error messages produced from URL title retrieval
 - `nick_response_str` (string) the message to send for the nick response feature
+- `reconnect_timeout` (u32) amount of time to wait before reconnecting.
 
 The `[database]` section contains options for the database, as follows:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ or, if `$XDG_CONFIG_PATH` is set:
 The `--conf` parameter may be provided multiple times, in order to connect to
 multiple servers/networks.
 
+Additionally, a search path may be specified with the `--conf-dir=<dir>` CLI
+argument, with the effect that any valid configurations existing
+non-recursively under this path will be loaded. This option may also be
+specified multiple times.
+
 ### Configuration file options
 
 The configuration includes settings pertaining to the IRC server the bot will

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ The database type may be specified in the `[database]` configuration section,
 as field `type`. A corresponding path to use for the database may be given as
 field, `path`.
 
+For SQLite, if no path is specified, a default path will be used, and a
+database will be created according to the network name specified in the
+`[network]` section of the configuration.
+
 ## Install from source
 
 ### Cargo

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ operation, specified in the `[features]` section:
   "docs.rs".
 - `nick_response` (bool) respond with a message if bot is pinged in a message
   with no other action to perform.
+- `reconnect` (bool) reconnect to the server after errors.
 
 The `[parameters]` section includes a number of tunable parameters:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ connect to, including among other things:
 - The nick the bot will use when joining
 - Channels to join
 
+The `[network]` section gives some metadata for the network the configuration
+will connect to, including:
+
+- `name` (string) an identifier for the network.
+
 It is also possible to configure a number of optional features for the bot's
 operation, specified in the `[features]` section:
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ It is also possible to configure a number of optional features for the bot's
 operation, specified in the `[features]` section:
 
 - `mask_highlights` (bool) inserts invisible characters to defeat highlight
-  regexes
+  regexes.
 - `send_notice` (bool) causes the bot to respond with notices rather than
-  private messages
-- `report_metadata` (bool) if enabled, causes image metadata to be reported
+  private messages.
+- `report_metadata` (bool) if enabled, causes image metadata to be reported.
 - `report_mime` (bool) if enabled, causes mime types to be reported, if no
   other title or metadata is found.
-- `history` (bool) enable previous post information using a database
+- `history` (bool) enable previous post information using a database.
 - `invite` (bool) if enabled, `/invite` will cause the bot to join a channel.
 - `autosave` (bool) if enabled, `/invite` and `/kick` will automatically write
   out the active configuration with an updated list of channels.
@@ -102,18 +102,17 @@ operation, specified in the `[features]` section:
 
 The `[parameters]` section includes a number of tunable parameters:
 
-- `url_limit` (u8) max number of URLs to process for each message (default: 10)
-- `accept_lang` (string) language requested in http content requests
-  (default: "en")
+- `url_limit` (u8) max number of URLs to process for each message (default: 10).
+- `accept_lang` (string) language requested in http content requests (default: "en").
 - `status_channels` (list) channel(s) to create, join and message with any
-  error messages produced from URL title retrieval
-- `nick_response_str` (string) the message to send for the nick response feature
+  error messages produced from URL title retrieval.
+- `nick_response_str` (string) the message to send for the nick response feature.
 - `reconnect_timeout` (u32) amount of time to wait before reconnecting.
 
 The `[database]` section contains options for the database, as follows:
 
-- `path` (string) is the path to a database file (for `sqlite`)
-- `type` (string) is the type of database to use, e.g. `sqlite`
+- `type` (string) is the type of database to use, e.g. `sqlite`.
+- `path` (string) is the path to a database file (for `sqlite`).
 
 If no configuration file exists at the expected location, a default-valued
 configuration file will be created. An example configuration is provided as

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ argument, with the effect that any valid configurations existing
 non-recursively under this path will be loaded. This option may also be
 specified multiple times.
 
+When searching for configurations using the `--conf-dir` option, any
+configurations in which the `enable` field under the `[network]` section is set
+to false will not be loaded.
+
 ### Configuration file options
 
 The configuration includes settings pertaining to the IRC server the bot will
@@ -69,6 +73,9 @@ The `[network]` section gives some metadata for the network the configuration
 will connect to, including:
 
 - `name` (string) an identifier for the network.
+- `enable` (bool) whether to enable this network - only used when a
+  configuration is found in a search path using the `--conf-dir` CLI argument,
+  and ignored if the configuration is explicitly loaded.
 
 It is also possible to configure a number of optional features for the bot's
 operation, specified in the `[features]` section:

--- a/README.md
+++ b/README.md
@@ -104,17 +104,17 @@ configuration file will be created. An example configuration is provided as
 
 A database may be specified, which is used to cache posted links, so that if
 the same URL is posted again, the original poster and the time posted is added
-to the returned message. This feature can be enabled or disabled within the
-`[features]` section of the configuration file.
+to the returned message. This feature can be enabled using the `history`
+feature within the `[features]` section of the configuration file.
 
-History is also enabled if a path is specified with `--db=<path>` or in the
-configuration, the given path will be used to store a SQLite database,
-otherwise a default path will be used according to the XDG specification. If no
-file exists at the specified path, it will be created.
+Currently supported database type strings are:
 
-If history is enabled, no database type is specified in the `[database]`
-section of the configuration, and no database path has been specified, an
-in-memory database will be used.
+- `in-memory`
+- `sqlite`
+
+The database type may be specified in the `[database]` configuration section,
+as field `type`. A corresponding path to use for the database may be given as
+field, `path`.
 
 ## Install from source
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -18,8 +18,7 @@ status_channels = []
 nick_response_str = ""
 
 [database]
-path = ""
-type = "in-memory"
+type = "InMemory"
 
 [connection]
 nickname = "url-bot-rs"

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,3 +1,6 @@
+[network]
+name = "default"
+
 [features]
 report_metadata = false
 report_mime = false

--- a/example.config.toml
+++ b/example.config.toml
@@ -14,6 +14,7 @@ send_errors_to_poster = false
 reply_with_errors = false
 partial_urls = false
 nick_response = false
+reconnect = false
 
 [parameters]
 url_limit = 10

--- a/example.config.toml
+++ b/example.config.toml
@@ -21,7 +21,7 @@ status_channels = []
 nick_response_str = ""
 
 [database]
-type = "InMemory"
+type = "in-memory"
 
 [connection]
 nickname = "url-bot-rs"

--- a/example.config.toml
+++ b/example.config.toml
@@ -21,6 +21,7 @@ url_limit = 10
 accept_lang = "en"
 status_channels = []
 nick_response_str = ""
+reconnect_timeout = 10
 
 [database]
 type = "in-memory"

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,5 +1,6 @@
 [network]
 name = "default"
+enable = true
 
 [features]
 report_metadata = false

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -8,6 +8,7 @@ extern crate url_bot_rs;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
+#[macro_use] extern crate failure;
 
 extern crate irc;
 extern crate rusqlite;
@@ -15,7 +16,6 @@ extern crate docopt;
 extern crate itertools;
 extern crate regex;
 extern crate lazy_static;
-extern crate failure;
 extern crate time;
 extern crate reqwest;
 extern crate cookie;

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -77,14 +77,12 @@ fn main() {
         .and_then(|d| d.version(Some(VERSION.to_string())).deserialize())
         .unwrap_or_else(|e| e.exit());
 
-    // don't output colours or include timestamps on stderr if piped
-    let (coloured_output, mut timestamp) = if is(Stream::Stderr) {
-        (ColorChoice::Auto, Timestamp::Second)
+    // avoid timestamping when piped, e.g. systemd
+    let timestamp = if is(Stream::Stderr) || args.flag_timestamp {
+        Timestamp::Second
     } else {
-        (ColorChoice::Never, Timestamp::Off)
+        Timestamp::Off
     };
-
-    if args.flag_timestamp { timestamp = Timestamp::Second };
 
     stderrlog::new()
         .module(module_path!())
@@ -95,7 +93,7 @@ fn main() {
         ])
         .verbosity(args.flag_verbose + MIN_VERBOSITY)
         .timestamp(timestamp)
-        .color(coloured_output)
+        .color(ColorChoice::Never)
         .init()
         .unwrap();
 

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -99,7 +99,9 @@ fn main() {
     // default instance
     if args.flag_conf.is_empty() {
         let dirs = ProjectDirs::from("org", "", "url-bot-rs").unwrap();
-        run_instance(&dirs.config_dir().join("config.toml"));
+        let conf = dirs.config_dir().join("config.toml");
+        let db = dirs.data_local_dir().join("history.db");
+        run_instance(&conf, Some(&db));
     }
 
     // threaded instances
@@ -108,7 +110,7 @@ fn main() {
         .map(|conf| {
             thread::spawn(move || {
                 let conf = conf.clone();
-                run_instance(&conf);
+                run_instance(&conf, None);
             })
         })
         .collect();
@@ -118,9 +120,10 @@ fn main() {
     }
 }
 
-fn run_instance(conf: &PathBuf) {
+fn run_instance(conf: &PathBuf, db: Option<&PathBuf>) {
     let mut rtd: Rtd = Rtd::new()
         .conf(conf)
+        .db(db)
         .load()
         .unwrap_or_else(|err| {
             error!("loading configuration: {}", err);

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -52,7 +52,7 @@ const USAGE: &str = "
 URL munching IRC bot.
 
 Usage:
-    url-bot-rs [options] [-v...] [--conf=PATH...]
+    url-bot-rs [options] [-v...] [--conf=PATH...] [--conf-dir=DIR...]
 
 Options:
     -h --help           Show this help message.

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -150,6 +150,7 @@ fn run_instance(conf: &PathBuf, db: Option<&PathBuf>) -> Result<(), Error> {
     if rtd.conf.network.enable {
         info!("using configuration: {}", conf.display());
     } else {
+        warn!("ignoring configuration: {}", conf.display());
         return Ok(());
     }
 

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -142,12 +142,16 @@ fn get_configs(args: &Args) -> Result<Vec<PathBuf>, Error> {
 }
 
 fn run_instance(conf: &PathBuf, db: Option<&PathBuf>) -> Result<(), Error> {
-    info!("using configuration: {}", conf.display());
-
     let mut rtd: Rtd = Rtd::new()
         .conf(conf)
         .db(db)
         .load()?;
+
+    if rtd.conf.network.enable {
+        info!("using configuration: {}", conf.display());
+    } else {
+        return Ok(());
+    }
 
     let db = if let Some(ref path) = rtd.paths.db {
         info!("using database: {}", path.display());

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -144,14 +144,14 @@ fn get_configs(args: &Args) -> Result<Vec<PathBuf>, Error> {
 }
 
 fn run_instance(conf: &PathBuf, db: Option<&PathBuf>) -> Result<(), Error> {
-    let sleep_dur = Duration::seconds(10).to_std().unwrap();
-
     let rtd: Rtd = Rtd::new()
         .conf(conf)
         .db(db)
         .load()?;
 
     let net = &rtd.conf.network.name;
+    let timeout = rtd.conf.params.reconnect_timeout as i64;
+    let sleep_dur = Duration::seconds(timeout).to_std().unwrap();
 
     if rtd.conf.network.enable {
         info!("[{}] using configuration: {}", net, conf.display());
@@ -170,7 +170,7 @@ fn run_instance(conf: &PathBuf, db: Option<&PathBuf>) -> Result<(), Error> {
             break Ok(());
         }
 
-        info!("[{}] reconnecting in 10 seconds", net);
+        info!("[{}] reconnecting in {} seconds", net, timeout);
         thread::sleep(sleep_dur);
     }
 }

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -131,11 +131,13 @@ fn main() {
 }
 
 fn get_configs(args: &Args) -> Result<Vec<PathBuf>, Error> {
-    let dir_configs: Vec<PathBuf> = args.flag_conf_dir
+    let dir_configs = args.flag_conf_dir
         .iter()
-        .map(|d| find_configs_in_dir(d).unwrap())
-        .flatten()
-        .collect();
+        .try_fold(vec![], |mut result, dir| -> Result<_, Error> {
+            let dir_configs = find_configs_in_dir(dir)?;
+            result.extend(dir_configs);
+            Ok(result)
+        })?;
     Ok([&dir_configs[..], &args.flag_conf[..]].concat())
 }
 

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -47,13 +47,12 @@ const USAGE: &str = "
 URL munching IRC bot.
 
 Usage:
-    url-bot-rs [options] [-v...] [--db=PATH]
+    url-bot-rs [options] [-v...]
 
 Options:
     -h --help       Show this help message.
     --version       Print version.
     -v --verbose    Show extra information.
-    -d --db=PATH    Use a sqlite database at PATH.
     -c --conf=PATH  Use configuration file at PATH.
     -t --timestamp  Force timestamps.
 ";
@@ -61,7 +60,6 @@ Options:
 #[derive(Debug, Deserialize, Default)]
 pub struct Args {
     flag_verbose: usize,
-    flag_db: Option<PathBuf>,
     flag_conf: Option<PathBuf>,
     flag_timestamp: bool,
 }
@@ -100,7 +98,6 @@ fn main() {
     // get a run-time configuration data structure
     let mut rtd: Rtd = Rtd::new()
         .conf(&args.flag_conf)
-        .db(args.flag_db)
         .load()
         .unwrap_or_else(|err| {
             error!("Error loading configuration: {}", err);
@@ -122,7 +119,7 @@ fn main() {
             process::exit(1);
         })
     } else {
-        if rtd.history { info!("Using in-memory database"); }
+        if rtd.conf.features.history { info!("using in-memory database"); }
         Database::open_in_memory().unwrap()
     };
 

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -42,6 +42,7 @@ use std::thread;
 use std::path::PathBuf;
 use stderrlog::{Timestamp, ColorChoice};
 use atty::{is, Stream};
+use directories::ProjectDirs;
 
 // docopt usage string
 const USAGE: &str = "
@@ -95,6 +96,13 @@ fn main() {
         .init()
         .unwrap();
 
+    // default instance
+    if args.flag_conf.is_empty() {
+        let dirs = ProjectDirs::from("org", "", "url-bot-rs").unwrap();
+        run_instance(&dirs.config_dir().join("config.toml"));
+    }
+
+    // threaded instances
     let threads: Vec<_> = args.flag_conf
         .into_iter()
         .map(|conf| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,20 @@ use directories::BaseDirs;
 
 use super::VERSION;
 
-// serde structures defining the configuration file structure
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct Network {
+    pub name: String,
+}
+
+impl Default for Network {
+    fn default() -> Self {
+        Self {
+            name: "default".into(),
+        }
+    }
+}
+
 #[derive(Default, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct Features {
@@ -74,6 +87,7 @@ impl Default for Parameters {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct Conf {
+    pub network: Network,
     pub features: Features,
     #[serde(rename = "parameters")]
     pub params: Parameters,
@@ -119,6 +133,7 @@ impl Conf {
 impl Default for Conf {
     fn default() -> Self {
         Self {
+            network: Network::default(),
             features: Features::default(),
             params: Parameters::default(),
             database: Database::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -231,7 +231,7 @@ impl Rtd {
     fn get_sqlite_path(&self) -> Option<PathBuf> {
         let mut path = self.conf.database.path.as_ref()
             .filter(|p| !p.is_empty())
-            .map(|p| PathBuf::from(p));
+            .map(PathBuf::from);
 
         if self.paths.db.is_some() && path.is_none() {
             path = self.paths.db.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ use directories::{BaseDirs, ProjectDirs};
 use super::VERSION;
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(default)]
 pub struct Network {
     pub name: String,
     pub enable: bool,
@@ -30,7 +29,6 @@ impl Default for Network {
 }
 
 #[derive(Default, Serialize, Deserialize, Clone)]
-#[serde(default)]
 pub struct Features {
     pub report_metadata: bool,
     pub report_mime: bool,
@@ -59,7 +57,6 @@ impl Default for DbType {
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]
-#[serde(default)]
 pub struct Database {
     #[serde(rename = "type")]
     pub db_type: DbType,
@@ -67,7 +64,6 @@ pub struct Database {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(default)]
 pub struct Parameters {
     pub url_limit: u8,
     pub accept_lang: String,
@@ -87,12 +83,14 @@ impl Default for Parameters {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(default)]
 pub struct Conf {
+    #[serde(default)]
     pub network: Network,
+    #[serde(default)]
     pub features: Features,
-    #[serde(rename = "parameters")]
+    #[serde(default, rename = "parameters")]
     pub params: Parameters,
+    #[serde(default)]
     pub database: Database,
     #[serde(rename = "connection")]
     pub client: IrcConfig,

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,16 +229,12 @@ impl Rtd {
     }
 
     fn get_sqlite_path(&self) -> Option<PathBuf> {
-        let mut path = if let Some(p) = &self.conf.database.path {
-            if p.is_empty() {
-                None
-            } else {
-                Some(p.into())
-            }
-        } else if let Some(p) = &self.paths.db {
-            Some(p.into())
-        } else {
-            None
+        let mut path = self.conf.database.path.as_ref()
+            .filter(|p| !p.is_empty())
+            .map(|p| PathBuf::from(p));
+
+        if self.paths.db.is_some() && path.is_none() {
+            path = self.paths.db.clone();
         };
 
         if path.is_none() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,7 @@ pub struct Rtd {
     pub paths: Paths,
     /// configuration file data
     pub conf: Conf,
+    pub history: bool,
 }
 
 #[derive(Default, Clone)]
@@ -159,14 +160,8 @@ impl Rtd {
         Rtd::default()
     }
 
-    pub fn conf(&mut self, path: &Option<PathBuf>) -> &mut Self {
-        let dirs = ProjectDirs::from("org", "", "url-bot-rs").unwrap();
-
-        self.paths.conf = match path {
-            Some(ref cp) => expand_tilde(cp),
-            None => dirs.config_dir().join("config.toml")
-        };
-
+    pub fn conf(&mut self, path: &PathBuf) -> &mut Self {
+        self.paths.conf = expand_tilde(path);
         self
     }
 
@@ -265,7 +260,7 @@ mod tests {
     /// test that the example configuration file parses without error
     fn load_example_conf() {
         Rtd::new()
-            .conf(&Some(PathBuf::from("example.config.toml")))
+            .conf(&"example.config.toml".into())
             .load()
             .unwrap();
     }
@@ -276,7 +271,7 @@ mod tests {
         let cfg_path = tmp_dir.path().join("config.toml");
 
         Rtd::new()
-            .conf(&Some(cfg_path))
+            .conf(&cfg_path)
             .load()
             .unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -347,6 +347,32 @@ mod tests {
     }
 
     #[test]
+    fn conf_add_remove_channel() {
+        let mut rtd = Rtd::default();
+        check_channels(&rtd, "#url-bot-rs", 1);
+
+        rtd.conf.add_channel("#cheese".to_string());
+        check_channels(&rtd, "#cheese", 2);
+
+        rtd.conf.add_channel("#cheese-2".to_string());
+        check_channels(&rtd, "#cheese-2", 3);
+
+        rtd.conf.remove_channel(&"#cheese-2".to_string());
+        let c = rtd.conf.client.channels.clone().unwrap();
+
+        assert!(!c.contains(&"#cheese-2".to_string()));
+        assert_eq!(2, c.len());
+    }
+
+    fn check_channels(rtd: &Rtd, contains: &str, len: usize) {
+        let c = rtd.conf.client.channels.clone().unwrap();
+        println!("{:?}", c);
+
+        assert!(c.contains(&contains.to_string()));
+        assert_eq!(len, c.len());
+    }
+
+    #[test]
     fn test_expand_tilde() {
         let homedir: PathBuf = BaseDirs::new()
             .unwrap()

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,6 @@ use toml;
 use std::path::{Path, PathBuf};
 use irc::client::data::Config as IrcConfig;
 use failure::Error;
-use std::fmt;
 use directories::{BaseDirs, ProjectDirs};
 
 use super::VERSION;
@@ -250,18 +249,6 @@ impl Rtd {
         }
     }
 }
-
-/// implementation of Display trait for multiple structs in this module
-macro_rules! impl_display {
-    ($($t:ty),+) => {
-        $(impl fmt::Display for $t {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "{}", toml::ser::to_string(self).unwrap())
-            }
-        })+
-    }
-}
-impl_display!(Features, Parameters, Database);
 
 fn ensure_parent_dir(file: &Path) -> Result<bool, Error> {
     let without_path = file.components().count() == 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -570,4 +570,17 @@ mod tests {
 
         assert!(rtd.is_err());
     }
+
+    #[test]
+    fn test_allow_loading_with_missing_optional_fields() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("fake.toml");
+        let mut f = File::create(&cfg_path).unwrap();
+        f.write_all(b"[connection]\n[features]\n[parameters]\n").unwrap();
+
+        Rtd::new()
+            .conf(&cfg_path)
+            .load()
+            .unwrap();
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ impl Default for Network {
 }
 
 #[derive(Default, Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct Features {
     pub report_metadata: bool,
     pub report_mime: bool,
@@ -57,6 +58,7 @@ impl Default for DbType {
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default)]
 pub struct Database {
     #[serde(rename = "type")]
     pub db_type: DbType,
@@ -64,6 +66,7 @@ pub struct Database {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct Parameters {
     pub url_limit: u8,
     pub accept_lang: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,12 +17,14 @@ use super::VERSION;
 #[serde(default)]
 pub struct Network {
     pub name: String,
+    pub enable: bool,
 }
 
 impl Default for Network {
     fn default() -> Self {
         Self {
             name: "default".into(),
+            enable: true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,7 +146,6 @@ pub struct Rtd {
     pub paths: Paths,
     /// configuration file data
     pub conf: Conf,
-    pub history: bool,
 }
 
 #[derive(Default, Clone)]
@@ -158,11 +157,6 @@ pub struct Paths {
 impl Rtd {
     pub fn new() -> Self {
         Rtd::default()
-    }
-
-    pub fn db(&mut self, path: Option<PathBuf>) -> &mut Self {
-        self.paths.db = path;
-        self
     }
 
     pub fn conf(&mut self, path: &Option<PathBuf>) -> &mut Self {
@@ -207,24 +201,16 @@ impl Rtd {
     fn set_db_info(&mut self) {
         let dirs = ProjectDirs::from("org", "", "url-bot-rs").unwrap();
 
-        let (hist_enabled, db_path) = if let Some(ref path) = self.paths.db {
-            // enable history when db path given as CLI argument
-            (true, Some(PathBuf::from(path)))
-        } else if !self.conf.features.history {
-            // no path specified on CLI, and history disabled in configuration
-            (false, None)
+        let db_path = if !self.conf.features.history {
+            None
         } else if !self.conf.database.path.is_empty() {
-            // (non-empty) db path specified in configuration
-            (true, Some(PathBuf::from(&self.conf.database.path)))
+            Some(PathBuf::from(&self.conf.database.path))
         } else if self.conf.database.db_type == "sqlite" {
-            // database type is sqlite, but no path given, use default
-            (true, Some(dirs.data_local_dir().join("history.db")))
+            Some(dirs.data_local_dir().join("history.db"))
         } else {
-            // use in-memory database
-            (true, None)
+            None
         };
 
-        self.history = hist_enabled;
         self.paths.db = db_path.map(|p| expand_tilde(&p));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -364,6 +364,27 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_path_empty_config_path_does_not_override_explicit() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("config.toml");
+        let db_path = tmp_dir.path().join("cfg.test.db");
+
+        let mut cfg = Conf::default();
+        cfg.features.history = true;
+        cfg.database.db_type = DbType::Sqlite;
+        cfg.database.path = Some("".to_string());
+        cfg.write(&cfg_path).unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .db(Some(&db_path))
+            .load()
+            .unwrap();
+
+        assert_eq!(rtd.paths.db, Some(db_path));
+    }
+
+    #[test]
     fn sqlite_path_default() {
         let tmp_dir = tempdir().unwrap();
         let cfg_path = tmp_dir.path().join("config.toml");

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,7 +188,7 @@ impl Rtd {
         // get db path, and history
         self.set_db_info();
 
-        if let Some(dp) = self.paths.db.clone() {
+        if let Some(dp) = &self.paths.db {
             create_dir_if_missing(dp.parent().unwrap())?;
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,17 +157,12 @@ impl Default for Conf {
     }
 }
 
-// run time data structure. this is used to pass around mutable runtime data
-// where it's needed, including command line arguments, configuration file
-// settings, any parameters defined based on both of these sources, and
-// any other data used at runtime
 #[derive(Default, Clone)]
 pub struct Rtd {
     /// paths
     pub paths: Paths,
     /// configuration file data
     pub conf: Conf,
-    pub history: bool,
 }
 
 #[derive(Default, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,9 +45,10 @@ pub struct Features {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
 pub enum DbType {
     InMemory,
-    SQLite,
+    Sqlite,
 }
 
 impl Default for DbType {
@@ -220,7 +221,7 @@ impl Rtd {
         if self.conf.features.history {
             match self.conf.database.db_type {
                 DbType::InMemory => { None },
-                DbType::SQLite => {
+                DbType::Sqlite => {
                     let mut path = if let Some(p) = &self.conf.database.path {
                         if p.is_empty() {
                             None
@@ -328,7 +329,7 @@ mod tests {
 
         let mut cfg = Conf::default();
         cfg.features.history = true;
-        cfg.database.db_type = DbType::SQLite;
+        cfg.database.db_type = DbType::Sqlite;
         cfg.write(&cfg_path).unwrap();
 
         let rtd = Rtd::new()
@@ -349,7 +350,7 @@ mod tests {
 
         let mut cfg = Conf::default();
         cfg.features.history = true;
-        cfg.database.db_type = DbType::SQLite;
+        cfg.database.db_type = DbType::Sqlite;
         cfg.database.path = Some(db_path_cfg.to_str().unwrap().to_string());
         cfg.write(&cfg_path).unwrap();
 
@@ -369,7 +370,7 @@ mod tests {
 
         let mut cfg = Conf::default();
         cfg.features.history = true;
-        cfg.database.db_type = DbType::SQLite;
+        cfg.database.db_type = DbType::Sqlite;
         cfg.write(&cfg_path).unwrap();
 
         let rtd = Rtd::new()
@@ -413,7 +414,7 @@ mod tests {
 
         let mut cfg = Conf::default();
         cfg.features.history = true;
-        cfg.database.db_type = DbType::SQLite;
+        cfg.database.db_type = DbType::Sqlite;
         cfg.database.path = Some(db_path_cfg.to_str().unwrap().to_string());
         cfg.write(&cfg_path).unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,11 @@ impl Rtd {
         self
     }
 
+    pub fn db(&mut self, path: Option<&PathBuf>) -> &mut Self {
+        self.paths.db = path.map(|p| expand_tilde(p));
+        self
+    }
+
     pub fn load(&mut self) -> Result<Self, Error> {
         ensure_parent_dir(&self.paths.conf)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -341,6 +341,28 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_path_config_overrides_explicit() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("config.toml");
+        let db_path = tmp_dir.path().join("test.db");
+        let db_path_cfg = tmp_dir.path().join("cfg.test.db");
+
+        let mut cfg = Conf::default();
+        cfg.features.history = true;
+        cfg.database.db_type = DbType::SQLite;
+        cfg.database.path = Some(db_path_cfg.to_str().unwrap().to_string());
+        cfg.write(&cfg_path).unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .db(Some(&db_path))
+            .load()
+            .unwrap();
+
+        assert_eq!(rtd.paths.db, Some(db_path_cfg));
+    }
+
+    #[test]
     fn test_ensure_parent() {
         let tmp_dir = tempdir().unwrap();
         let tmp_path = tmp_dir.path().join("test/test.file");

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ pub struct Features {
     pub reply_with_errors: bool,
     pub partial_urls: bool,
     pub nick_response: bool,
+    pub reconnect: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,6 +363,49 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_path_default() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("config.toml");
+
+        let mut cfg = Conf::default();
+        cfg.features.history = true;
+        cfg.database.db_type = DbType::SQLite;
+        cfg.write(&cfg_path).unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .load()
+            .unwrap();
+
+        let dirs = ProjectDirs::from("org", "", "url-bot-rs").unwrap();
+        let default = dirs.data_local_dir().join("history.default.db");
+        println!("database path: {}", default.to_str().unwrap());
+        assert_eq!(rtd.paths.db, Some(default));
+
+        cfg.network.name = "test_net".to_string();
+        cfg.write(&cfg_path).unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .load()
+            .unwrap();
+
+        let default = dirs.data_local_dir().join("history.test_net.db");
+        println!("database path: {}", default.to_str().unwrap());
+        assert_eq!(rtd.paths.db, Some(default.clone()));
+
+        cfg.database.path = Some("".to_string());
+        cfg.write(&cfg_path).unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .load()
+            .unwrap();
+
+        assert_eq!(rtd.paths.db, Some(default));
+    }
+
+    #[test]
     fn test_ensure_parent() {
         let tmp_dir = tempdir().unwrap();
         let tmp_path = tmp_dir.path().join("test/test.file");

--- a/src/config.rs
+++ b/src/config.rs
@@ -406,6 +406,26 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_path_config_overrides_default() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("config.toml");
+        let db_path_cfg = tmp_dir.path().join("cfg.test.db");
+
+        let mut cfg = Conf::default();
+        cfg.features.history = true;
+        cfg.database.db_type = DbType::SQLite;
+        cfg.database.path = Some(db_path_cfg.to_str().unwrap().to_string());
+        cfg.write(&cfg_path).unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .load()
+            .unwrap();
+
+        assert_eq!(rtd.paths.db, Some(db_path_cfg));
+    }
+
+    #[test]
     fn test_ensure_parent() {
         let tmp_dir = tempdir().unwrap();
         let tmp_path = tmp_dir.path().join("test/test.file");

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,7 @@ pub struct Parameters {
     pub accept_lang: String,
     pub status_channels: Vec<String>,
     pub nick_response_str: String,
+    pub reconnect_timeout: u32,
 }
 
 impl Default for Parameters {
@@ -81,7 +82,8 @@ impl Default for Parameters {
             url_limit: 10,
             accept_lang: "en".to_string(),
             status_channels: vec![],
-            nick_response_str: "".to_string()
+            nick_response_str: "".to_string(),
+            reconnect_timeout: 10,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -321,6 +321,26 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_path_explicit() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("config.toml");
+        let db_path = tmp_dir.path().join("test.db");
+
+        let mut cfg = Conf::default();
+        cfg.features.history = true;
+        cfg.database.db_type = DbType::SQLite;
+        cfg.write(&cfg_path).unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .db(Some(&db_path))
+            .load()
+            .unwrap();
+
+        assert_eq!(rtd.paths.db, Some(db_path));
+    }
+
+    #[test]
     fn test_ensure_parent() {
         let tmp_dir = tempdir().unwrap();
         let tmp_path = tmp_dir.path().join("test/test.file");

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,6 +271,21 @@ mod tests {
     }
 
     #[test]
+    fn load_write_default() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("config.toml");
+
+        Rtd::new()
+            .conf(&Some(cfg_path))
+            .load()
+            .unwrap();
+
+        let example = fs::read_to_string("example.config.toml").unwrap();
+        let written = fs::read_to_string(cfg_path).unwrap();
+        assert_eq!(example, written);
+    }
+
+    #[test]
     fn test_ensure_parent() {
         let tmp_dir = tempdir().unwrap();
         let tmp_path = tmp_dir.path().join("test/test.file");

--- a/src/config.rs
+++ b/src/config.rs
@@ -548,10 +548,28 @@ mod tests {
         f.write_all(b"not a config").unwrap();
         assert_eq!(find_configs_in_dir(cfg_dir).unwrap().count(), 10);
 
+        let mut f = File::create(cfg_dir.join("fake.toml")).unwrap();
+        f.write_all(b"[this]\nis = \"valid toml\"").unwrap();
+        assert_eq!(find_configs_in_dir(cfg_dir).unwrap().count(), 10);
+
         fs::create_dir(cfg_dir.join("fake.dir")).unwrap();
         assert_eq!(find_configs_in_dir(cfg_dir).unwrap().count(), 10);
 
         write_n_configs(33, cfg_dir);
         assert_eq!(find_configs_in_dir(cfg_dir).unwrap().count(), 32);
+    }
+
+    #[test]
+    fn test_do_not_promiscuously_load_any_toml() {
+        let tmp_dir = tempdir().unwrap();
+        let cfg_path = tmp_dir.path().join("fake.toml");
+        let mut f = File::create(&cfg_path).unwrap();
+        f.write_all(b"[this]\nis = \"valid toml\"").unwrap();
+
+        let rtd = Rtd::new()
+            .conf(&cfg_path)
+            .load();
+
+        assert!(rtd.is_err());
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -167,7 +167,7 @@ fn process_titles(rtd: &Rtd, db: &Database, msg: &Msg) -> impl Iterator<Item = T
             continue;
         }
 
-        info!("RESOLVE <{}>", token);
+        info!("[{}] RESOLVE <{}>", rtd.conf.network.name, token);
 
         // try to get the title from the url
         let title = match resolve_url(token, rtd, db) {
@@ -227,8 +227,7 @@ fn process_titles(rtd: &Rtd, db: &Database, msg: &Msg) -> impl Iterator<Item = T
         // limit response length, see RFC1459
         msg = utf8_truncate(&msg, 510);
 
-        // log
-        info!("{}", msg);
+        info!("[{}] {}", rtd.conf.network.name, msg);
 
         responses.push(TitleResp::TITLE(msg.to_string()));
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -188,7 +188,7 @@ fn process_titles(rtd: &Rtd, db: &Database, msg: &Msg) -> impl Iterator<Item = T
         };
 
         // check for pre-post
-        let pre_post = if rtd.history {
+        let pre_post = if rtd.conf.features.history {
             db.check_prepost(token)
         } else {
             Ok(None)
@@ -211,7 +211,7 @@ fn process_titles(rtd: &Rtd, db: &Database, msg: &Msg) -> impl Iterator<Item = T
             },
             Ok(None) => {
                 // add new log entry to database, if posted in a channel
-                if rtd.history && msg.is_chanmsg {
+                if rtd.conf.features.history && msg.is_chanmsg {
                     if let Err(err) = db.add_log(&entry) {
                         error!("SQL error: {}", err);
                     }
@@ -465,7 +465,7 @@ mod tests {
     #[test]
     fn test_process_titles_repost() {
         let mut rtd = Rtd::default();
-        rtd.history = true;
+        rtd.conf.features.history = true;
 
         let msg = Msg::new(&rtd, "testnick", "#test", "http://0.0.0.0:8084/");
         let db = Database::open_in_memory().unwrap();


### PR DESCRIPTION
This adds the ability to connect to multiple IRC networks by specifying multiple configurations on the command line. Re-connection to IRC servers after failure is also added. Aside from this, add few other small touch-ups and a bug fix in configuration loading, and add a few more tests.