### PR TITLE
Fix clippy warning

### DIFF
--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -118,7 +118,6 @@ fn main() {
         .into_iter()
         .map(|conf| {
             thread::spawn(move || {
-                let conf = conf.clone();
                 run_instance(&conf, None).unwrap_or_else(|e| {
                     error!("{}", e);
                     process::exit(1);


### PR DESCRIPTION
```
warning: reidundant clone
   --> src/bin/url-bot-rs.rs:121:32
    |
121 |                 let conf = conf.clone();
    |                                ^^^^^^^^ help: remove this
    |
    = note: `#[warn(clippy::redundant_clone)]` on by default
note: this value is dropped without further use
   --> src/bin/url-bot-rs.rs:121:28
    |
121 |                 let conf = conf.clone();
    |                            ^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
```