### PR TITLE
Optionally disable cross-channel history posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add configuration feature to limit history to same channels
+
 # v0.2.4
 
 - Allow build with bundled, statically linked, SQLite

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ operation, specified in the `[features]` section:
 - `report_mime` (bool) if enabled, causes mime types to be reported, if no
   other title or metadata is found.
 - `history` (bool) enable previous post information using a database.
+- `cross_channel_history` (bool) if enabled, only post pre-post information to
+  the same channel as the original post.
 - `invite` (bool) if enabled, `/invite` will cause the bot to join a channel.
 - `autosave` (bool) if enabled, `/invite` and `/kick` will automatically write
   out the active configuration with an updated list of channels.

--- a/example.config.toml
+++ b/example.config.toml
@@ -8,6 +8,7 @@ report_mime = false
 mask_highlights = false
 send_notice = false
 history = false
+cross_channel_history = false
 invite = false
 autosave = false
 send_errors_to_poster = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct Features {
     pub mask_highlights: bool,
     pub send_notice: bool,
     pub history: bool,
+    pub cross_channel_history: bool,
     pub invite: bool,
     pub autosave: bool,
     pub send_errors_to_poster: bool,

--- a/src/message.rs
+++ b/src/message.rs
@@ -194,6 +194,20 @@ fn process_titles(rtd: &Rtd, db: &Database, msg: &Msg) -> impl Iterator<Item = T
             Ok(None)
         };
 
+        // limit pre-post to same channel if required by configuration
+        let pre_post = if rtd.conf.features.cross_channel_history {
+            pre_post
+        } else {
+            pre_post
+                .map(|p| p.and_then(|p| {
+                    if p.channel == msg.target {
+                        Some(p)
+                    } else {
+                        None
+                    }
+                }))
+        };
+
         // generate response string
         let mut msg = match pre_post {
             Ok(Some(previous_post)) => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -194,6 +194,12 @@ fn process_titles(rtd: &Rtd, db: &Database, msg: &Msg) -> impl Iterator<Item = T
             Ok(None)
         };
 
+        let pre_post_found = if let Ok(Some(_)) = pre_post {
+            true
+        } else {
+            false
+        };
+
         // limit pre-post to same channel if required by configuration
         let pre_post = if rtd.conf.features.cross_channel_history {
             pre_post
@@ -225,7 +231,7 @@ fn process_titles(rtd: &Rtd, db: &Database, msg: &Msg) -> impl Iterator<Item = T
             },
             Ok(None) => {
                 // add new log entry to database, if posted in a channel
-                if rtd.conf.features.history && msg.is_chanmsg {
+                if rtd.conf.features.history && !pre_post_found && msg.is_chanmsg {
                     if let Err(err) = db.add_log(&entry) {
                         error!("SQL error: {}", err);
                     }
@@ -530,7 +536,7 @@ mod tests {
 
         rtd.conf.features.mask_highlights = false;
 
-        let msg2 = Msg::new(&rtd, "testnick", "#test2", "http://0.0.0.0:8084/");
+        let msg2 = Msg::new(&rtd, "testnick", "#test2", "http://127.0.0.1:8084/");
 
         // cross-posted history is disabled
         let res: Vec<_> = process_titles(&rtd, &db, &msg2).collect();


### PR DESCRIPTION
Following discussion in #270 