### PR TITLE
Don't install useless debian package dependencies in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,6 @@ jobs:
         components: clippy
         override: true
 
-    - name: Install dependencies
-      run: sudo apt-get install -y libsqlite3-dev
-
     - name: Build tests
       run: cargo test --verbose --no-run --features "sqlite_bundled"
 


### PR DESCRIPTION
In useless Ubuntu repositories, which seem to be down once in a while.