### PR TITLE
Remove dependency on cookie crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Remove `cookie` dependency
 - Update to upstream `reqwest`, refactoring HTTP request code significantly
 - Replace `time` with `chrono`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,12 +74,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
-
-[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,7 +184,7 @@ checksum = "f0fee792e164f78f5fe0c296cc2eb3688a2ca2b70cdff33040922d298203f0c4"
 dependencies = [
  "num-integer",
  "num-traits",
- "time 0.1.43",
+ "time",
 ]
 
 [[package]]
@@ -226,17 +220,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 dependencies = [
- "time 0.1.43",
+ "time",
  "url 1.7.2",
-]
-
-[[package]]
-name = "cookie"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c60ef6d0bbf56ad2674249b6bb74f2c6aeb98b98dd57b5d3e37cace33011d69"
-dependencies = [
- "time 0.2.16",
 ]
 
 [[package]]
@@ -245,13 +230,13 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2a7e5bf5517bf3c3f4358f13d3ec2092419ac2332aa8593605c957da73d491"
 dependencies = [
- "cookie 0.12.0",
+ "cookie",
  "idna 0.2.0",
  "log",
  "publicsuffix",
  "serde",
  "serde_json",
- "time 0.1.43",
+ "time",
  "url 2.1.1",
 ]
 
@@ -402,12 +387,6 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "docopt"
@@ -812,7 +791,7 @@ dependencies = [
  "log",
  "pin-project",
  "socket2",
- "time 0.1.43",
+ "time",
  "tokio 0.2.21",
  "tower-service",
  "want",
@@ -1695,7 +1674,7 @@ checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
  "base64 0.12.3",
  "bytes 0.5.5",
- "cookie 0.12.0",
+ "cookie",
  "cookie_store",
  "encoding_rs",
  "futures-core",
@@ -1714,7 +1693,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_urlencoded",
- "time 0.1.43",
+ "time",
  "tokio 0.2.21",
  "tokio-tls 0.3.1",
  "url 2.1.1",
@@ -1739,7 +1718,7 @@ dependencies = [
  "bitflags",
  "libsqlite3-sys",
  "lru-cache",
- "time 0.1.43",
+ "time",
 ]
 
 [[package]]
@@ -1936,12 +1915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,15 +1972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
-name = "standback"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "stderrlog"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,55 +1983,6 @@ dependencies = [
  "termcolor",
  "thread_local 0.3.4",
 ]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "serde",
- "serde_derive",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string_cache"
@@ -2225,44 +2140,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
-dependencies = [
- "cfg-if",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "standback",
- "syn 1.0.33",
 ]
 
 [[package]]
@@ -2671,7 +2548,6 @@ dependencies = [
  "atty",
  "built",
  "chrono",
- "cookie 0.13.3",
  "diff",
  "directories",
  "docopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ regex = "1.3.9"
 lazy_static = "1.4.0"
 failure = "0.1.8"
 reqwest = { version = "0.10.6", features = ["blocking", "cookies"] }
-cookie = "0.13.3"
 serde_rusqlite = "0.14.0"
 mime = "0.3.16"
 humansize = "1.1.0"

--- a/src/bin/url-bot-get.rs
+++ b/src/bin/url-bot-get.rs
@@ -45,7 +45,6 @@ extern crate itertools;
 extern crate regex;
 extern crate failure;
 extern crate reqwest;
-extern crate cookie;
 extern crate image;
 extern crate mime;
 extern crate humansize;

--- a/src/bin/url-bot-rs.rs
+++ b/src/bin/url-bot-rs.rs
@@ -17,7 +17,6 @@ extern crate itertools;
 extern crate regex;
 extern crate lazy_static;
 extern crate reqwest;
-extern crate cookie;
 extern crate image;
 extern crate serde_rusqlite;
 extern crate mime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ extern crate lazy_static;
 extern crate failure;
 extern crate chrono;
 extern crate reqwest;
-extern crate cookie;
 extern crate image;
 extern crate serde_rusqlite;
 extern crate mime;


### PR DESCRIPTION
This is no longer needed since cookie functionality is now entirely handled by `reqwest`.