### PR TITLE
Add a configuration option to ignore nicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ The `[parameters]` section includes a number of tunable parameters:
   error messages produced from URL title retrieval.
 - `nick_response_str` (string) the message to send for the nick response feature.
 - `reconnect_timeout` (u32) amount of time to wait before reconnecting.
+- `ignore_nicks` (list) nicknames, messages from whom will result in no titles
+  being retrieved. For example to ignore messages from other bots in the same
+  channel.
 
 The `[http]` section contains options for HTTP requests used to obtain titles:
 

--- a/example.config.toml
+++ b/example.config.toml
@@ -31,6 +31,7 @@ url_limit = 10
 status_channels = []
 nick_response_str = ""
 reconnect_timeout = 10
+ignore_nicks = []
 
 [http]
 timeout_s = 10

--- a/example.multi.config.toml
+++ b/example.multi.config.toml
@@ -31,6 +31,7 @@ url_limit = 10
 status_channels = []
 nick_response_str = ""
 reconnect_timeout = 10
+ignore_nicks = []
 
 [bar.http]
 timeout_s = 10
@@ -87,6 +88,7 @@ url_limit = 10
 status_channels = []
 nick_response_str = ""
 reconnect_timeout = 10
+ignore_nicks = []
 
 [foo.http]
 timeout_s = 10

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,7 @@ pub struct Parameters {
     pub status_channels: Vec<String>,
     pub nick_response_str: String,
     pub reconnect_timeout: u64,
+    pub ignore_nicks: Vec<String>,
 }
 
 impl Default for Parameters {
@@ -98,6 +99,7 @@ impl Default for Parameters {
             status_channels: vec![],
             nick_response_str: "".to_string(),
             reconnect_timeout: 10,
+            ignore_nicks: vec![],
         }
     }
 }


### PR DESCRIPTION
A list of nicks to be ignored can now be added to the configuration. For nicks contained in this list, no titles will be retrieved.

Resolves #20