### PR TITLE
Add optional openssl/vendored dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,21 +1350,21 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -1375,14 +1375,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.58"
+name = "openssl-src"
+version = "111.17.0+1.1.1m"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2729,6 +2739,7 @@ dependencies = [
  "log",
  "man",
  "mime",
+ "openssl",
  "phf 0.7.24",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ stderrlog = "0.5.1"
 atty = "0.2.14"
 scraper = { version = "0.12.0", default-features = false, features = [] }
 phf = "0.7.24"
+openssl = { version = "0.10.38", features = ["vendored"], optional = true }
 
 [dependencies.image]
 version = "0.22.5"
@@ -59,6 +60,7 @@ features = ["gif_codec", "jpeg", "png_codec", "pnm", "tiff", "bmp"]
 
 [features]
 default = []
+openssl_vendored = ["openssl/vendored"]
 sqlite_bundled = ["rusqlite/bundled"]
 
 [package.metadata.deb]


### PR DESCRIPTION
Needed now for static builds.

I don't know if there are cases where one would want to install `openssl/vendored` or `rusqlite/bundled` separately. Perhaps they should be combined under a `static` target?